### PR TITLE
Added support for AFNetworking

### DIFF
--- a/POSInputStreamLibrary/NSInputStream+POS.h
+++ b/POSInputStreamLibrary/NSInputStream+POS.h
@@ -14,5 +14,6 @@
 + (NSInputStream *)pos_inputStreamWithAssetURL:(NSURL *)assetURL asynchronous:(BOOL)asynchronous;
 
 + (NSInputStream *)pos_inputStreamForCFNetworkWithAssetURL:(NSURL *)assetURL;
++ (NSInputStream *)pos_inputStreamForAFNetworkWithAssetURL:(NSURL *)assetURL openDispatchQueue:(dispatch_queue_t)openDispatchQueue;
 
 @end

--- a/POSInputStreamLibrary/NSInputStream+POS.m
+++ b/POSInputStreamLibrary/NSInputStream+POS.m
@@ -33,4 +33,13 @@
     return stream;
 }
 
++ (NSInputStream *)pos_inputStreamForAFNetworkWithAssetURL:(NSURL *)assetURL openDispatchQueue:(dispatch_queue_t)openDispatchQueue {
+    POSBlobInputStreamAssetDataSource *dataSource = [[POSBlobInputStreamAssetDataSource alloc] initWithAssetURL:assetURL];
+    dataSource.openSynchronously = YES;
+    dataSource.openDispatchQueue = openDispatchQueue;
+    POSBlobInputStream *stream = [[POSBlobInputStream alloc] initWithDataSource:dataSource];
+    stream.shouldNotifyCoreFoundationAboutStatusChange = NO;
+    return stream;
+}
+
 @end

--- a/POSInputStreamLibrary/POSAdjustedAssetReaderIOS7.h
+++ b/POSInputStreamLibrary/POSAdjustedAssetReaderIOS7.h
@@ -12,4 +12,11 @@
 
 @property (nonatomic, assign) CGFloat JPEGCompressionQuality;
 
+/*!
+    @brief Dispatch queue for getting ALAsset.
+
+    @remarks See POSBlobInputStreamAssetDataSource.h
+ */
+@property (nonatomic, strong) dispatch_queue_t completionDispatchQueue;
+
 @end

--- a/POSInputStreamLibrary/POSAdjustedAssetReaderIOS7.m
+++ b/POSInputStreamLibrary/POSAdjustedAssetReaderIOS7.m
@@ -60,7 +60,7 @@ completionHandler:(void (^)(POSLength assetSize, NSError *error))completionHandl
                 }
             }
         }
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(self.completionDispatchQueue ?: dispatch_get_main_queue(), ^{
             completionHandler(self.imageData.length, error);
         });
     });

--- a/POSInputStreamLibrary/POSAdjustedAssetReaderIOS8.h
+++ b/POSInputStreamLibrary/POSAdjustedAssetReaderIOS8.h
@@ -18,4 +18,11 @@
 /// can take from the info dictionary with 'PHImageFileURLKey' key.
 @property (nonatomic, assign) long long suspiciousSize;
 
+/*!
+ @brief Dispatch queue for getting ALAsset.
+
+ @remarks See POSBlobInputStreamAssetDataSource.h
+ */
+@property (nonatomic, strong) dispatch_queue_t completionDispatchQueue;
+
 @end

--- a/POSInputStreamLibrary/POSAdjustedAssetReaderIOS8.m
+++ b/POSInputStreamLibrary/POSAdjustedAssetReaderIOS8.m
@@ -35,7 +35,9 @@ completionHandler:(void (^)(POSLength assetSize, NSError *error))completionHandl
     }
     void (^openCompletionBlock)(NSData *, NSError *) = ^void(NSData *assetData, NSError *error) {
         self.imageData = assetData;
-        completionHandler([_imageData length], error);
+        dispatch_async(self.completionDispatchQueue ?: dispatch_get_main_queue(), ^{
+            completionHandler([_imageData length], error);
+        });
     };
     [self p_fetchAssetDataForAsset:asset completionBlock:^(NSData *assetData, NSError *error) {
         if ([assetData length] <= _suspiciousSize) {

--- a/POSInputStreamLibrary/POSBlobInputStreamAssetDataSource.h
+++ b/POSInputStreamLibrary/POSBlobInputStreamAssetDataSource.h
@@ -59,6 +59,15 @@ typedef NS_ENUM(NSInteger, POSBlobInputStreamAssetDataSourceErrorCode) {
  */
 @property (nonatomic, assign) long long adjustedImageMaximumSize;
 
+/*!
+    @brief Dispatch queue for getting ALAsset.
+
+    @discussion By default when stream is opened, current dispatch queue is locked and
+                ALAsset is retrieved on main dispatch queue. AFNetworking also uses
+                main dispatch queue to open NSInputStream so we cannot use it.
+ */
+@property (nonatomic, assign) dispatch_queue_t openDispatchQueue;
+
 /// The designated initializer.
 - (instancetype)initWithAssetURL:(NSURL *)assetURL;
 

--- a/POSInputStreamLibrary/POSBlobInputStreamAssetDataSource.h
+++ b/POSInputStreamLibrary/POSBlobInputStreamAssetDataSource.h
@@ -66,7 +66,7 @@ typedef NS_ENUM(NSInteger, POSBlobInputStreamAssetDataSourceErrorCode) {
                 ALAsset is retrieved on main dispatch queue. AFNetworking also uses
                 main dispatch queue to open NSInputStream so we cannot use it.
  */
-@property (nonatomic, assign) dispatch_queue_t openDispatchQueue;
+@property (nonatomic, strong) dispatch_queue_t openDispatchQueue;
 
 /// The designated initializer.
 - (instancetype)initWithAssetURL:(NSURL *)assetURL;

--- a/POSInputStreamLibrary/POSBlobInputStreamAssetDataSource.m
+++ b/POSInputStreamLibrary/POSBlobInputStreamAssetDataSource.m
@@ -157,7 +157,7 @@ typedef NS_ENUM(int, ResetMode) {
 - (void)p_open {
     id<POSLocking> lock = [self p_lockForOpening];
     [lock lock];
-    dispatch_async(dispatch_get_main_queue(), ^{ @autoreleasepool {
+    dispatch_async(self.openDispatchQueue ?: dispatch_get_main_queue(), ^{ @autoreleasepool {
         self.assetsLibrary = [ALAssetsLibrary new];
         [_assetsLibrary pos_assetForURL:_assetURL resultBlock:^(ALAsset *asset, ALAssetsGroup *assetsGroup) {
             ALAssetRepresentation *assetRepresentation = [asset defaultRepresentation];
@@ -213,9 +213,11 @@ typedef NS_ENUM(int, ResetMode) {
 
 - (id<POSLocking>)p_lockForOpening {
     if ([self shouldOpenSynchronously]) {
-        // If you want open stream synchronously you should
-        // do that in some worker thread to avoid deadlock.
-        NSParameterAssert(![[NSThread currentThread] isMainThread]);
+        if (!self.openDispatchQueue) {
+            // If you want open stream synchronously you should
+            // do that in some worker thread to avoid deadlock.
+            NSParameterAssert(![[NSThread currentThread] isMainThread]);
+        }
         return [POSGCDLock new];
     } else {
         return [POSDummyLock new];

--- a/POSInputStreamLibrary/POSBlobInputStreamAssetDataSource.m
+++ b/POSInputStreamLibrary/POSBlobInputStreamAssetDataSource.m
@@ -201,11 +201,13 @@ typedef NS_ENUM(int, ResetMode) {
         representation.size <= _adjustedImageMaximumSize) {
         POSAdjustedAssetReaderIOS8 *assetReader = [POSAdjustedAssetReaderIOS8 new];
         assetReader.suspiciousSize = _adjustedImageMaximumSize;
+        assetReader.completionDispatchQueue = self.openDispatchQueue;
         return assetReader;
     }
     if (representation.metadata[@"AdjustmentXMP"] != nil) {
         POSAdjustedAssetReaderIOS7 *assetReader = [POSAdjustedAssetReaderIOS7 new];
         assetReader.JPEGCompressionQuality = _adjustedJPEGCompressionQuality;
+        assetReader.completionDispatchQueue = self.openDispatchQueue;
         return assetReader;
     }
     return [POSFastAssetReader new];


### PR DESCRIPTION
By default when stream is opened, current dispatch queue is locked and ALAsset is retrieved on main dispatch queue.

AFNetworking also uses main dispatch queue to open NSInputStream so we cannot use it.
